### PR TITLE
Fix code scanning alert no. 40: Database query built from user-controlled sources

### DIFF
--- a/src/controllers/questionnaire/questionnaire.controllers.js
+++ b/src/controllers/questionnaire/questionnaire.controllers.js
@@ -341,7 +341,10 @@ const createQuestionnaire = async (req, res) => {
 
 const updateQuestionnaireById = async (req, res) => {
   try {
-    const { name, original, published, categories } = req.body;
+    let { name, original, published, categories } = req.body;
+    if (typeof name !== 'string' || typeof original !== 'string' || typeof published !== 'boolean' || !Array.isArray(categories)) {
+      return res.status(400).json({ error: "Datos inválidos proporcionados." });
+    }
 
     let name1 = name.trimLeft();
     if (!name1) {
@@ -358,7 +361,12 @@ const updateQuestionnaireById = async (req, res) => {
 
     const updatedQuestionnaire = await Questionnaire.findByIdAndUpdate(
       req.params.id,
-      { name, original, published, categories },
+      { 
+        name: { $eq: name }, 
+        original: { $eq: original }, 
+        published: { $eq: published }, 
+        categories: { $eq: categories } 
+      },
       { new: true }
     ).populate("categories");
 


### PR DESCRIPTION
Fixes [https://github.com/vladimirCeli/Progresreqs-Backend/security/code-scanning/40](https://github.com/vladimirCeli/Progresreqs-Backend/security/code-scanning/40)

To fix the problem, we need to ensure that the user-provided data is properly sanitized before being used in the query object. We can use the `$eq` operator to ensure that the user input is interpreted as a literal value and not as a query object. Additionally, we should validate the data types of the user-provided values to ensure they are as expected.

1. Use the `$eq` operator for the `name`, `original`, `published`, and `categories` fields in the query object.
2. Validate the data types of `name`, `original`, `published`, and `categories` before using them in the query.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
