### PR TITLE
Fix code scanning alert no. 39: Database query built from user-controlled sources

### DIFF
--- a/src/controllers/questionnaire/questionnaire.controllers.js
+++ b/src/controllers/questionnaire/questionnaire.controllers.js
@@ -212,7 +212,10 @@ const updateQuestionnaireByIdInPublishedOrUnpublished = async (req, res) => {
 
 const updateQuestionnaireByIdSteps = async (req, res) => {
   try {
-    const { steps } = req.body;
+    let { steps } = req.body;
+    if (typeof steps !== "number") {
+      return res.status(400).json({ message: "Invalid steps value." });
+    }
 
     // Obtener el cuestionario actual por su ID
     const currentQuestionnaire = await Questionnaire.findById(req.params.id);

--- a/src/controllers/questionnaire/questionnaire.controllers.js
+++ b/src/controllers/questionnaire/questionnaire.controllers.js
@@ -247,10 +247,10 @@ const updateQuestionnaireByIdSteps = async (req, res) => {
 
     res.status(200).json(updatedQuestionnaire);
   } catch (error) {
-    console.error("Error al actualizar el cuestionario por ID:", message);
+    console.error("Error al actualizar el cuestionario por ID:", error);
     res
       .status(500)
-      .json({ message: "Hubo un error al actualizar el cuestionario." });
+      .json({ error: "Hubo un error al actualizar el cuestionario." });
   }
 };
 


### PR DESCRIPTION
Fixes [https://github.com/vladimirCeli/Progresreqs-Backend/security/code-scanning/39](https://github.com/vladimirCeli/Progresreqs-Backend/security/code-scanning/39)

To fix the problem, we need to ensure that the `steps` value is properly sanitized or validated before being used in the MongoDB query. The best way to fix this is to validate that `steps` is a number and not a query object. This can be done by checking the type of `steps` before using it in the query.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
