### PR TITLE
Fix code scanning alert no. 37: Database query built from user-controlled sources

### DIFF
--- a/src/controllers/questionnaire/questionnaire.controllers.js
+++ b/src/controllers/questionnaire/questionnaire.controllers.js
@@ -193,6 +193,9 @@ const selectAdditionalQuestionnaire = async (req, res) => {
 const updateQuestionnaireByIdInPublishedOrUnpublished = async (req, res) => {
   try {
     const { published } = req.body;
+    if (typeof published !== "boolean") {
+      return res.status(400).json({ error: "Invalid input for published field." });
+    }
     const updatedQuestioBynnaire = await Questionnaire.findByIdAndUpdate(
       req.params.id,
       { published },


### PR DESCRIPTION
Fixes [https://github.com/vladimirCeli/Progresreqs-Backend/security/code-scanning/37](https://github.com/vladimirCeli/Progresreqs-Backend/security/code-scanning/37)

To fix the problem, we need to ensure that the `published` field is properly validated before being used in the query. Since `published` is expected to be a boolean, we can validate that the input is indeed a boolean value. If the input is not a boolean, we should return an error response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
