### PR TITLE
Fix code scanning alert no. 36: Database query built from user-controlled sources

### DIFF
--- a/src/controllers/questionnaire/questionnaire.controllers.js
+++ b/src/controllers/questionnaire/questionnaire.controllers.js
@@ -165,9 +165,12 @@ const selectAdditionalQuestionnaire = async (req, res) => {
     }
     console.log(selectedQuestionnaire);
 
+    if (typeof selectedId !== "string") {
+      return res.status(400).json({ error: "Invalid questionnaire ID." });
+    }
     const hasResponses = await Response.exists({
       project_id,
-      questionnaire_id: selectedId,
+      questionnaire_id: { $eq: selectedId },
     });
 
     if (!hasResponses) {


### PR DESCRIPTION
Fixes [https://github.com/vladimirCeli/Progresreqs-Backend/security/code-scanning/36](https://github.com/vladimirCeli/Progresreqs-Backend/security/code-scanning/36)

To fix the problem, we need to ensure that the `selectedId` is treated as a literal value and not as a query object. This can be achieved by using the `$eq` operator in the MongoDB query. Additionally, we should validate that `selectedId` is a string before using it in the query.

1. Use the `$eq` operator to ensure that `selectedId` is interpreted as a literal value.
2. Validate that `selectedId` is a string before using it in the query.
3. Update the MongoDB query to use the `$eq` operator.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
