### PR TITLE
Fix code scanning alert no. 35: Database query built from user-controlled sources

### DIFF
--- a/src/controllers/questionnaire/questionnaire.controllers.js
+++ b/src/controllers/questionnaire/questionnaire.controllers.js
@@ -153,7 +153,7 @@ const selectAdditionalQuestionnaire = async (req, res) => {
     const { selectedId } = req.body;
 
     const selectedQuestionnaire = await Questionnaire.find({
-      _id: selectedId,
+      _id: { $eq: selectedId },
       published: true,
       steps: 0,
     });


### PR DESCRIPTION
Fixes [https://github.com/vladimirCeli/Progresreqs-Backend/security/code-scanning/35](https://github.com/vladimirCeli/Progresreqs-Backend/security/code-scanning/35)

To fix the problem, we need to ensure that the `selectedId` is properly sanitized before being used in the MongoDB query. The best way to do this is to use the `$eq` operator to ensure that the user input is interpreted as a literal value and not as a query object. This will prevent any potential NoSQL injection attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
