### PR TITLE
Fix code scanning alert no. 33: Database query built from user-controlled sources

### DIFF
--- a/src/controllers/questionnaire/response.controllers.js
+++ b/src/controllers/questionnaire/response.controllers.js
@@ -53,9 +53,13 @@ const updateResponseById = async (req, res) => {
       return res.status(400).json({ message: 'El nombre de la respuesta no puede estar vacío.' });
     }
 
+    if (typeof project_id !== 'string' || typeof questionnaire_id !== 'string') {
+      return res.status(400).json({ message: 'Invalid project_id or questionnaire_id' });
+    }
+
     const response = await Response.findByIdAndUpdate(
       req.params.id,
-      { project_id, name, questions, questionnaire_id },
+      { project_id: { $eq: project_id }, name, questions, questionnaire_id: { $eq: questionnaire_id } },
       { new: true }
     );
     if (!response) {


### PR DESCRIPTION
Fixes [https://github.com/vladimirCeli/Progresreqs-Backend/security/code-scanning/33](https://github.com/vladimirCeli/Progresreqs-Backend/security/code-scanning/33)

To fix the problem, we need to ensure that the user-provided data is properly validated and sanitized before being used in the query object. We can use the `$eq` operator to ensure that the user input is interpreted as a literal value and not as a query object. Additionally, we should validate the input to ensure it meets the expected format.

1. Validate the user-provided data to ensure it meets the expected format.
2. Use the `$eq` operator to safely embed the user-provided data into the query object.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
