### PR TITLE
Fix code scanning alert no. 31: Database query built from user-controlled sources

### DIFF
--- a/src/controllers/questionnaire/categorie.controllers.js
+++ b/src/controllers/questionnaire/categorie.controllers.js
@@ -43,6 +43,9 @@ const createCategory = async (req, res) => {
 const updateCategoryById = async (req, res) => {
   try {
     const { name, original, practices } = req.body;
+    if (typeof name !== 'string' || typeof original !== 'boolean' || !Array.isArray(practices)) {
+      return res.status(400).json({ error: 'Datos de entrada no válidos.' });
+    }
 
     const existingCategory = await Category.findById(req.params.id);
 
@@ -58,7 +61,7 @@ const updateCategoryById = async (req, res) => {
 
     const updatedCategory = await Category.findByIdAndUpdate(
       req.params.id,
-      { name, original, practices },
+      { $set: { name, original, practices } },
       { new: true }
     ).populate('practices');
     if (!updatedCategory) {


### PR DESCRIPTION
Fixes [https://github.com/vladimirCeli/Progresreqs-Backend/security/code-scanning/31](https://github.com/vladimirCeli/Progresreqs-Backend/security/code-scanning/31)

To fix the problem, we need to ensure that the user-provided data is sanitized or validated before being used in the MongoDB query. The best way to fix this is to validate the input data to ensure it is of the expected type and format. For MongoDB, we can also use the `$set` operator to update specific fields, which helps in preventing injection attacks.

1. Validate the input data to ensure it is of the expected type and format.
2. Use the `$set` operator to update specific fields in the MongoDB document.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
