### PR TITLE
Fix code scanning alert no. 30: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "sequelize": "^6.33.0",
     "sequelize-cli": "^6.6.1",
     "uuid": "^9.0.1",
-    "validator": "^13.12.0"
+    "validator": "^13.12.0",
+    "express-rate-limit": "^7.5.0"
   },
   "devDependencies": {
     "nodemon": "^3.0.1"

--- a/src/routes/questionnaire/questionnaire.routes.js
+++ b/src/routes/questionnaire/questionnaire.routes.js
@@ -1,4 +1,5 @@
 const { Router } = require("express");
+const RateLimit = require("express-rate-limit");
 const {
   getAllQuestionnaires,
   getQuestionnaireById,
@@ -14,6 +15,11 @@ const {
 } = require("../../controllers/questionnaire/questionnaire.controllers");
 
 const router = Router();
+
+const limiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // max 100 requests per windowMs
+});
 
 router.get("/questionnaire", getAllQuestionnaires);
 
@@ -38,6 +44,6 @@ router.delete("/questionnaire/:id", deleteQuestionnaireById);
 
 router.put("/questionnaire/:id", updateQuestionnaireById);
 
-router.get("/questionnaire/:id", getQuestionnaireById);
+router.get("/questionnaire/:id", limiter, getQuestionnaireById);
 
 module.exports = router;


### PR DESCRIPTION
Fixes [https://github.com/vladimirCeli/Progresreqs-Backend/security/code-scanning/30](https://github.com/vladimirCeli/Progresreqs-Backend/security/code-scanning/30)

To fix the problem, we need to introduce rate limiting to the Express application. The best way to do this is by using the `express-rate-limit` package, which allows us to easily set up and apply rate limiting to specific routes or the entire application.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `src/routes/questionnaire/questionnaire.routes.js` file.
3. Set up a rate limiter with appropriate configuration (e.g., maximum of 100 requests per 15 minutes).
4. Apply the rate limiter to the specific route that handles the `getQuestionnaireById` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
