### PR TITLE
Fix code scanning alert no. 5: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "sequelize": "^6.33.0",
     "sequelize-cli": "^6.6.1",
     "uuid": "^9.0.1",
-    "validator": "^13.12.0"
+    "validator": "^13.12.0",
+    "express-rate-limit": "^7.5.0"
   },
   "devDependencies": {
     "nodemon": "^3.0.1"

--- a/src/routes/questionnaire/practice.routes.js
+++ b/src/routes/questionnaire/practice.routes.js
@@ -4,17 +4,24 @@ const {  getAllPractices,
     createPractice,
     updatePracticeById,
     deletePracticeById, } = require('../../controllers/questionnaire/practice.controllers')
+const rateLimit = require('express-rate-limit');
 
 const router = Router()
 
-router.get('/subsection', getAllPractices )
+// set up rate limiter: maximum of 100 requests per 15 minutes
+const limiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // max 100 requests per windowMs
+});
 
-router.get('/subsection/:id', getPracticeById )
+router.get('/subsection', limiter, getAllPractices )
 
-router.post('/subsection', createPractice )
+router.get('/subsection/:id', limiter, getPracticeById )
 
-router.delete('/subsection/:id', deletePracticeById )
+router.post('/subsection', limiter, createPractice )
 
-router.put('/subsection/:id', updatePracticeById )
+router.delete('/subsection/:id', limiter, deletePracticeById )
+
+router.put('/subsection/:id', limiter, updatePracticeById )
 
 module.exports = router


### PR DESCRIPTION
Fixes [https://github.com/vladimirCeli/Progresreqs-Backend/security/code-scanning/5](https://github.com/vladimirCeli/Progresreqs-Backend/security/code-scanning/5)

To fix the problem, we need to introduce rate limiting to the route handlers in the `src/routes/questionnaire/practice.routes.js` file. We will use the `express-rate-limit` package to limit the number of requests that can be made to the route handlers within a specified time window. This will help prevent denial-of-service attacks by limiting the rate at which requests are accepted.

We will:
1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `src/routes/questionnaire/practice.routes.js` file.
3. Set up a rate limiter with appropriate configuration.
4. Apply the rate limiter to the route handlers.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
