### PR TITLE
Fix code scanning alert no. 16: Missing rate limiting

### DIFF
--- a/src/routes/refreshToken.routes.js
+++ b/src/routes/refreshToken.routes.js
@@ -1,9 +1,16 @@
 const {Router} = require('express')
 const { handleRefreshToken } = require('../controllers/refreshToken.controllers')
+const rateLimit = require('express-rate-limit')
+
+// Create a rate limiter: maximum of 100 requests per 15 minutes
+const limiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+})
 
 const router = Router()
 
-router.get('/refresh', handleRefreshToken )
+router.get('/refresh', limiter, handleRefreshToken )
 
 
 


### PR DESCRIPTION
Fixes [https://github.com/vladimirCeli/Progresreqs-Backend/security/code-scanning/16](https://github.com/vladimirCeli/Progresreqs-Backend/security/code-scanning/16)

To fix the problem, we need to introduce rate limiting to the `handleRefreshToken` route. The best way to do this is by using the `express-rate-limit` middleware, which allows us to easily set up rate limiting for specific routes.

1. Install the `express-rate-limit` package if it is not already installed.
2. Import the `express-rate-limit` package in the `src/routes/refreshToken.routes.js` file.
3. Create a rate limiter with appropriate settings (e.g., maximum number of requests per time window).
4. Apply the rate limiter to the `/refresh` route.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
