### PR TITLE
Fix code scanning alert no. 24: Missing rate limiting

### DIFF
--- a/src/routes/questionnaire/questionnaire.routes.js
+++ b/src/routes/questionnaire/questionnaire.routes.js
@@ -12,8 +12,14 @@ const {
   updateQuestionnaireById,
   deleteQuestionnaireById,
 } = require("../../controllers/questionnaire/questionnaire.controllers");
+const RateLimit = require('express-rate-limit');
 
 const router = Router();
+
+const limiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // max 100 requests per windowMs
+});
 
 router.get("/questionnaire", getAllQuestionnaires);
 
@@ -23,6 +29,7 @@ router.get("/questionnaire/published/:project_id", getQuestionnairePublished);
 
 router.put(
   "/questionnaire/editpublished/:id",
+  limiter,
   updateQuestionnaireByIdInPublishedOrUnpublished
 );
 


### PR DESCRIPTION
Fixes [https://github.com/vladimirCeli/Progresreqs-Backend/security/code-scanning/24](https://github.com/vladimirCeli/Progresreqs-Backend/security/code-scanning/24)

To fix the problem, we need to introduce rate limiting to the Express application. The best way to do this is by using the `express-rate-limit` package, which allows us to set up a rate limiter and apply it to specific routes or the entire application. In this case, we will apply the rate limiter to the specific route handler that performs database access.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `src/routes/questionnaire/questionnaire.routes.js` file.
3. Set up a rate limiter with appropriate configuration (e.g., maximum of 100 requests per 15 minutes).
4. Apply the rate limiter to the `updateQuestionnaireByIdInPublishedOrUnpublished` route handler.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
