### PR TITLE
Fix code scanning alert no. 20: Missing rate limiting

### DIFF
--- a/src/routes/questionnaire/categorie.routes.js
+++ b/src/routes/questionnaire/categorie.routes.js
@@ -1,4 +1,5 @@
 const {Router} = require('express')
+const RateLimit = require('express-rate-limit');
 const {   getAllCategories,
     getCategoryById,
     createCategory,
@@ -7,14 +8,19 @@ const {   getAllCategories,
 
 const router = Router()
 
-router.get('/categorie', getAllCategories )
+const limiter = RateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // max 100 requests per windowMs
+});
 
-router.get('/categorie/:id', getCategoryById )
+router.get('/categorie', limiter, getAllCategories )
 
-router.post('/categorie', createCategory )
+router.get('/categorie/:id', limiter, getCategoryById )
 
-router.delete('/categorie/:id', deleteCategoryById )
+router.post('/categorie', limiter, createCategory )
 
-router.put('/categorie/:id', updateCategoryById )
+router.delete('/categorie/:id', limiter, deleteCategoryById )
+
+router.put('/categorie/:id', limiter, updateCategoryById )
 
 module.exports = router


### PR DESCRIPTION
Fixes [https://github.com/vladimirCeli/Progresreqs-Backend/security/code-scanning/20](https://github.com/vladimirCeli/Progresreqs-Backend/security/code-scanning/20)

To fix the problem, we need to introduce rate limiting to the Express application. The best way to do this is by using the `express-rate-limit` package, which allows us to easily set up rate limiting middleware. We will configure the middleware to limit the number of requests to a reasonable number per a defined time window and apply it to the routes that perform expensive operations.

Specifically, we will:
1. Install the `express-rate-limit` package.
2. Import the package in the `src/routes/questionnaire/categorie.routes.js` file.
3. Configure the rate limiter with appropriate settings.
4. Apply the rate limiter to the routes that perform database access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
